### PR TITLE
Refactor restoreElement to separate Arrow and Elbow Arrow logic

### DIFF
--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -49,6 +49,7 @@ import { isInvisiblySmallElement } from "@excalidraw/element/sizeHelpers";
 import type { LocalPoint, Radians } from "@excalidraw/math";
 
 import type {
+  Arrowhead,
   ExcalidrawArrowElement,
   ExcalidrawElbowArrowElement,
   ExcalidrawElement,
@@ -240,6 +241,46 @@ const restoreElementWithProperties = <
   return ret;
 };
 
+const restoreLinearElementProperties = (
+  element: ExcalidrawLinearElement | (ExcalidrawElement & { type: "draw" }),
+): {
+  startBinding: ReturnType<typeof repairBinding>;
+  endBinding: ReturnType<typeof repairBinding>;
+  points: readonly LocalPoint[];
+  lastCommittedPoint: null;
+  x: number;
+  y: number;
+  startArrowhead: Arrowhead | null;
+  endArrowhead: Arrowhead | null;
+} & ReturnType<typeof getSizeFromPoints> => {
+  const {
+    startArrowhead = null,
+    endArrowhead = element.type === "arrow" ? "arrow" : null,
+  } = element;
+  let x = element.x;
+  let y = element.y;
+  let points = // migrate old arrow model to new one
+    !Array.isArray(element.points) || element.points.length < 2
+      ? [pointFrom(0, 0), pointFrom(element.width, element.height)]
+      : element.points;
+
+  if (points[0][0] !== 0 || points[0][1] !== 0) {
+    ({ points, x, y } = LinearElementEditor.getNormalizedPoints(element));
+  }
+
+  return {
+    startBinding: repairBinding(element, element.startBinding),
+    endBinding: repairBinding(element, element.endBinding),
+    lastCommittedPoint: null,
+    startArrowhead,
+    endArrowhead,
+    points,
+    x,
+    y,
+    ...getSizeFromPoints(points),
+  };
+};
+
 const restoreElement = (
   element: Exclude<ExcalidrawElement, ExcalidrawSelectionElement>,
 ): typeof element | null => {
@@ -314,72 +355,30 @@ const restoreElement = (
     // @ts-ignore LEGACY type
     // eslint-disable-next-line no-fallthrough
     case "draw":
-      const { startArrowhead = null, endArrowhead = null } = element;
-      let x = element.x;
-      let y = element.y;
-      let points = // migrate old arrow model to new one
-        !Array.isArray(element.points) || element.points.length < 2
-          ? [pointFrom(0, 0), pointFrom(element.width, element.height)]
-          : element.points;
-
-      if (points[0][0] !== 0 || points[0][1] !== 0) {
-        ({ points, x, y } = LinearElementEditor.getNormalizedPoints(element));
-      }
-
       return restoreElementWithProperties(element, {
         type:
           (element.type as ExcalidrawElementType | "draw") === "draw"
             ? "line"
             : element.type,
-        startBinding: repairBinding(element, element.startBinding),
-        endBinding: repairBinding(element, element.endBinding),
-        lastCommittedPoint: null,
-        startArrowhead,
-        endArrowhead,
-        points,
-        x,
-        y,
-        ...getSizeFromPoints(points),
+        ...restoreLinearElementProperties(element),
       });
     case "arrow": {
-      const { startArrowhead = null, endArrowhead = "arrow" } = element;
-      let x: number | undefined = element.x;
-      let y: number | undefined = element.y;
-      let points: readonly LocalPoint[] | undefined = // migrate old arrow model to new one
-        !Array.isArray(element.points) || element.points.length < 2
-          ? [pointFrom(0, 0), pointFrom(element.width, element.height)]
-          : element.points;
+      const commonProps = restoreLinearElementProperties(element);
 
-      if (points[0][0] !== 0 || points[0][1] !== 0) {
-        ({ points, x, y } = LinearElementEditor.getNormalizedPoints(element));
+      if (isElbowArrow(element)) {
+        return restoreElementWithProperties(element, {
+          ...commonProps,
+          elbowed: true,
+          fixedSegments: element.fixedSegments,
+          startIsSpecial: element.startIsSpecial,
+          endIsSpecial: element.endIsSpecial,
+        });
       }
 
-      const base = {
-        type: element.type,
-        startBinding: repairBinding(element, element.startBinding),
-        endBinding: repairBinding(element, element.endBinding),
-        lastCommittedPoint: null,
-        startArrowhead,
-        endArrowhead,
-        points,
-        x,
-        y,
-        elbowed: (element as ExcalidrawArrowElement).elbowed,
-        ...getSizeFromPoints(points),
-      } as const;
-
-      // TODO: Separate arrow from linear element
-      return isElbowArrow(element)
-        ? restoreElementWithProperties(element as ExcalidrawElbowArrowElement, {
-            ...base,
-            elbowed: true,
-            startBinding: repairBinding(element, element.startBinding),
-            endBinding: repairBinding(element, element.endBinding),
-            fixedSegments: element.fixedSegments,
-            startIsSpecial: element.startIsSpecial,
-            endIsSpecial: element.endIsSpecial,
-          })
-        : restoreElementWithProperties(element as ExcalidrawArrowElement, base);
+      return restoreElementWithProperties(element, {
+        ...commonProps,
+        elbowed: element.elbowed ?? false,
+      });
     }
 
     // generic elements

--- a/packages/excalidraw/tests/data/restore.test.ts
+++ b/packages/excalidraw/tests/data/restore.test.ts
@@ -5,8 +5,11 @@ import { DEFAULT_SIDEBAR, FONT_FAMILY, ROUNDNESS } from "@excalidraw/common";
 
 import { newElementWith } from "@excalidraw/element/mutateElement";
 import * as sizeHelpers from "@excalidraw/element/sizeHelpers";
+import { isElbowArrow } from "@excalidraw/element/typeChecks";
 
 import type {
+  ExcalidrawArrowElement,
+  ExcalidrawElbowArrowElement,
   ExcalidrawElement,
   ExcalidrawFreeDrawElement,
   ExcalidrawLinearElement,
@@ -816,5 +819,59 @@ describe("repairing bindings", () => {
         containerId: null,
       }),
     ]);
+  });
+});
+
+describe("restoreElements - Arrow Refactor", () => {
+  it("should restore regular arrow element correctly", () => {
+    const arrowElement = API.createElement({
+      type: "arrow",
+      id: "regular-arrow",
+      elbowed: false,
+      points: [pointFrom(0, 0), pointFrom(100, 100)],
+    });
+
+    const restoredElements = restore.restoreElements([arrowElement], null);
+    const restoredArrow = restoredElements[0] as ExcalidrawArrowElement;
+
+    expect(restoredArrow.type).toBe("arrow");
+    expect(restoredArrow.id).toBe("regular-arrow");
+    expect(restoredArrow.elbowed).toBe(false);
+    expect(isElbowArrow(restoredArrow)).toBe(false);
+    expect(restoredArrow.points).toEqual(arrowElement.points);
+  });
+
+  it("should restore elbow arrow element correctly", () => {
+    const elbowArrowElement = API.createElement({
+      type: "arrow",
+      id: "elbow-arrow",
+      elbowed: true,
+      points: [pointFrom(0, 0), pointFrom(50, 0), pointFrom(50, 100), pointFrom(100, 100)],
+    });
+
+    const restoredElements = restore.restoreElements([elbowArrowElement], null);
+    const restoredArrow = restoredElements[0] as ExcalidrawElbowArrowElement;
+
+    expect(restoredArrow.type).toBe("arrow");
+    expect(restoredArrow.id).toBe("elbow-arrow");
+    expect(restoredArrow.elbowed).toBe(true);
+    expect(isElbowArrow(restoredArrow)).toBe(true);
+    expect(restoredArrow.points).toEqual(elbowArrowElement.points);
+  });
+
+  it("should restore line element correctly", () => {
+    const lineElement = API.createElement({
+        type: "line",
+        id: "line",
+        points: [pointFrom(0, 0), pointFrom(100, 100)],
+    });
+
+    const restoredElements = restore.restoreElements([lineElement], null);
+    const restoredLine = restoredElements[0] as ExcalidrawLinearElement;
+
+    expect(restoredLine.type).toBe("line");
+    expect(restoredLine.id).toBe("line");
+    expect((restoredLine as any).elbowed).toBeUndefined();
+    expect(restoredLine.points).toEqual(lineElement.points);
   });
 });


### PR DESCRIPTION
This PR addresses the TODO item "Separate arrow from linear element" in `packages/excalidraw/data/restore.ts`.

It refactors the `restoreElement` function by extracting common linear element restoration logic into a helper function `restoreLinearElementProperties`. This helper is then used by both `line` (and legacy `draw`) elements and `arrow` elements.

For `arrow` elements, the logic is split to handle `ElbowArrow` separately from regular `Arrow`, ensuring that properties specific to elbow arrows (like `fixedSegments`) are only applied when appropriate, and that the code structure clearly reflects the distinction.

Existing tests were augmented with specific cases for Regular Arrow, Elbow Arrow, and Line restoration to prevent regression and verify the refactoring.

---
*PR created automatically by Jules for task [4167139799327591671](https://jules.google.com/task/4167139799327591671) started by @Toowiredd*