### PR TITLE
refactor(element): Use Set for suggested bindings deduplication

### DIFF
--- a/packages/element/src/binding.ts
+++ b/packages/element/src/binding.ts
@@ -375,26 +375,29 @@ export const getSuggestedBindingsForArrows = (
     return [];
   }
 
-  return (
-    selectedElements
-      .filter(isLinearElement)
-      .flatMap((element) =>
-        getOriginalBindingsIfStillCloseToArrowEnds(element, elementsMap, zoom),
-      )
-      .filter(
-        (element): element is NonDeleted<ExcalidrawBindableElement> =>
-          element !== null,
-      )
-      // Filter out bind candidates which are in the
-      // same selection / group with the arrow
-      //
-      // TODO: Is it worth turning the list into a set to avoid dupes?
-      .filter(
-        (element) =>
-          selectedElements.filter((selected) => selected.id === element?.id)
-            .length === 0,
-      )
-  );
+  const selectedElementIds = new Set(selectedElements.map((e) => e.id));
+  const suggestedBindings = new Set<NonDeleted<ExcalidrawBindableElement>>();
+
+  for (const element of selectedElements) {
+    if (isLinearElement(element)) {
+      const bindings = getOriginalBindingsIfStillCloseToArrowEnds(
+        element,
+        elementsMap,
+        zoom,
+      );
+      for (const binding of bindings) {
+        if (
+          binding !== null &&
+          isBindableElement(binding) &&
+          !selectedElementIds.has(binding.id)
+        ) {
+          suggestedBindings.add(binding as NonDeleted<ExcalidrawBindableElement>);
+        }
+      }
+    }
+  }
+
+  return Array.from(suggestedBindings);
 };
 
 export const maybeBindLinearElement = (

--- a/packages/element/tests/suggestedBindings.test.ts
+++ b/packages/element/tests/suggestedBindings.test.ts
@@ -1,0 +1,55 @@
+import { arrayToMap } from "@excalidraw/common";
+import { pointFrom } from "@excalidraw/math";
+
+import { getSuggestedBindingsForArrows } from "../src/binding";
+import { newElement, newArrowElement } from "../src/newElement";
+
+describe("getSuggestedBindingsForArrows", () => {
+  it("should remove duplicates from suggested bindings", () => {
+    const rect = newElement({
+      type: "rectangle",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+    });
+
+    // Arrow 1 pointing to rect from right
+    const arrow1 = newArrowElement({
+      type: "arrow",
+      x: 120,
+      y: 50,
+      width: 20,
+      height: 1,
+      points: [pointFrom(0, 0), pointFrom(-20, 0)],
+    });
+    // Manually set binding as newArrowElement resets it
+    arrow1.endBinding = { elementId: rect.id, focus: 0, gap: 0 };
+
+    // Arrow 2 pointing to rect from right, slightly below
+    const arrow2 = newArrowElement({
+      type: "arrow",
+      x: 120,
+      y: 60,
+      width: 20,
+      height: 1,
+      points: [pointFrom(0, 0), pointFrom(-20, 0)],
+    });
+    arrow2.endBinding = { elementId: rect.id, focus: 0, gap: 0 };
+
+    const elements = [rect, arrow1, arrow2];
+    const elementsMap = arrayToMap(elements);
+    const selectedElements = [arrow1, arrow2];
+
+    const result = getSuggestedBindingsForArrows(
+      selectedElements,
+      elementsMap,
+      { value: 1 } as any, // mock zoom
+    );
+
+    // Expect duplicates to be removed
+    // Currently (before fix) it likely returns rect twice
+    expect(result.length).toBe(1);
+    expect(result[0].id).toBe(rect.id);
+  });
+});


### PR DESCRIPTION
Refactors `getSuggestedBindingsForArrows` in `packages/element/src/binding.ts` to use `Set` data structures. This optimizes the filtering of selected elements (from O(N*M) to O(N)) and ensures that the suggested bindings list does not contain duplicates, as requested. A new unit test file `packages/element/tests/suggestedBindings.test.ts` was added to verify the fix and prevent regressions.

---
*PR created automatically by Jules for task [1131251573369967115](https://jules.google.com/task/1131251573369967115) started by @Toowiredd*